### PR TITLE
Replaces duplicate promises with original promises in the queue 

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-var-requires": 0,
     "no-constant-binary-expression": "error",
     "no-useless-concat": "error",

--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ const fetch = MyFetchQueue.getFetchMethod();
 
 ## Options
 
-| `Property` | `Description`                       | `Default Value` |
-| ---------- | ----------------------------------- | --------------- |
-| concurrent | number of concurrent fetch requests | 3               |
-| debug      | set debug mode                      | false           |
+| `Property`        | `Description`                                     | `Default Value`                           |
+| ----------------- | ------------------------------------------------- | --------------                            |
+| concurrent        | number of concurrent fetch requests               | 3                                         |
+| pauseQueueOnInit  | pause queue from the start                        | false                                     |
+| pre               | array of configs for pre-fetch-hooks              | []                                        |
+| queuingPatterns   | array of regular-expressions evaluate             | []                                        |
+| debug             | set debug mode                                    | false                                     |
+| keyBuilderParams  | array of fetch parameters to build the queue key  | ["url", "options.method", "options.body"] |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,14 @@ const fetch = MyFetchQueue.getFetchMethod();
 
 ## Options
 
-| `Property`        | `Description`                                     | `Default Value`                           |
-| ----------------- | ------------------------------------------------- | --------------                            |
-| concurrent        | number of concurrent fetch requests               | 3                                         |
-| pauseQueueOnInit  | pause queue from the start                        | false                                     |
-| pre               | array of configs for pre-fetch-hooks              | []                                        |
-| queuingPatterns   | array of regular-expressions evaluate             | []                                        |
-| debug             | set debug mode                                    | false                                     |
-| keyBuilderParams  | array of fetch parameters to build the queue key  | ["url", "options.method", "options.body"] |
+| `Property`        | `Description`                             | `Default Value`                           |
+| ----------------- | -------------------------------------     | --------------                            |
+| concurrent        | number of concurrent fetch requests       | 3                                         |
+| pauseQueueOnInit  | start queue with a paused state           | false                                     |
+| pre               | array of configs for pre-fetch-hooks      | []                                        |
+| queuingPatterns   | array of regex to queue matching requests | []                                        |
+| debug             | set debug mode                            | false                                     |
+| keyBuilderParams  | to build a unique key for queu            | ["url", "options.method", "options.body"] |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ const fetch = MyFetchQueue.getFetchMethod();
 | pre               | array of configs for pre-fetch-hooks      | []                                        |
 | queuingPatterns   | array of regex to queue matching requests | []                                        |
 | debug             | set debug mode                            | false                                     |
-| keyBuilderParams  | to build a unique key for queu            | ["url", "options.method", "options.body"] |
+| keyBuilderParams  | to build a unique key for queue           | ["url", "options.method", "options.body"] |
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3706,12 +3706,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -4895,10 +4896,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -5336,6 +5338,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -7697,12 +7700,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -8724,6 +8728,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -11890,12 +11895,12 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browserslist": {
@@ -12723,9 +12728,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -14833,12 +14838,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.1.3",
+  "version": "1.1.4-replace-duplicate-promise-ref.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/fetchq",
-      "version": "1.1.3",
+      "version": "1.1.4-replace-duplicate-promise-ref.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.1.4-replace-duplicate-promise-ref.1",
+  "version": "1.1.4-replace-duplicate-promise-ref.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/fetchq",
-      "version": "1.1.4-replace-duplicate-promise-ref.1",
+      "version": "1.1.4-replace-duplicate-promise-ref.2",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.1.4-replace-duplicate-promise-ref.0",
+  "version": "1.1.4-replace-duplicate-promise-ref.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/fetchq",
-      "version": "1.1.4-replace-duplicate-promise-ref.0",
+      "version": "1.1.4-replace-duplicate-promise-ref.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.1.3",
+  "version": "1.1.4-replace-duplicate-promise-ref.0",
   "description": "Queue for fetch requests",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.1.4-replace-duplicate-promise-ref.0",
+  "version": "1.1.4-replace-duplicate-promise-ref.1",
   "description": "Queue for fetch requests",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.1.4-replace-duplicate-promise-ref.1",
+  "version": "1.1.4-replace-duplicate-promise-ref.2",
   "description": "Queue for fetch requests",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ export class FetchQueue {
    * @param parameters - An object containing the parameters to be included in the key.
    * @returns A string representing the unique key for the fetch request.
    */
-  #keyBuilder(parameters: Record<string, any>): string {
+  #keyBuilder = (parameters: Record<string, any>) => {
     const requestKey: Record<string, any> = {};
 
     this.#keyBuilderParams.forEach((key) => {
@@ -185,7 +185,7 @@ export class FetchQueue {
     });
 
     return JSON.stringify(requestKey);
-  }
+  };
 
   /**
    * Returns the custom fetch function used by the FetchQueue class to handle queuing of fetch requests.

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export class FetchQueue {
     this.#debugLog("moving to next-item in queue", { activeRequests: this.#activeRequests, queueLength: this.#queueKey.length });
     delete this.#queue?.[key];
 
-    if (!Boolean(this.#queueKey.length) || !Boolean(Object.keys(this.#queue).length)) {
+    if (this.#queueKey.length === 0 || Object.keys(this.#queue).length === 0) {
       this.#queue = undefined;
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export class FetchQueue {
   #queuingPatterns: RegExp[];
 
   /**
-   * Array of keys of parameters to the fetch method to build the queue key
+   * Array of fetch parameters to build the queue key."
    */
   #keyBuilderParams: Array<string>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,6 +151,10 @@ export class FetchQueue {
 
     this.#debugLog("moving to next-item in queue", { activeRequests: this.#activeRequests, queueLength: this.#queueKey.length });
     delete this.#queue?.[key];
+
+    if (Boolean(this.#queueKey.length) && Boolean(Object.keys(this.#queue).length)) {
+      this.#queue = undefined;
+    }
   };
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export class FetchQueue {
   /**
    * A queue of tasks to be executed when a slot becomes available for a new fetch request.
    */
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   #queue: Record<string, { controller: AbortController; promise: () => Promise<Response>; resolve: (value: unknown) => void; reject: (reason?: any) => void }> | undefined;
 
   /**
@@ -284,6 +285,7 @@ export class FetchQueue {
             resolveFnFromPrevQueue(value);
           };
 
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
           rejectFn = (reason?: any) => {
             reject(reason);
             rejectFnFromPrevQueue(reason);

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,13 +311,13 @@ export class FetchQueue {
           const previousRejectHandler = this.#queue[requestKey].reject;
 
           resolveHandler = (value: unknown) => {
-            resolve(value);
             previousResolveHandler(value);
+            resolve(value);
           };
 
           rejectHandler = (reason?: any) => {
-            reject(reason);
             previousRejectHandler(reason);
+            reject(reason);
           };
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,9 +145,9 @@ export class FetchQueue {
     if (this.#pauseQueue) return this.#debugLog("queue paused! %d to be processed after resumption", this.#queueKey.length);
 
     const key = this.#queueKey.shift()!;
-    const nextTask = this.#queue?.[key];
+    const request = this.#queue?.[key];
 
-    nextTask.promise().then(nextTask.resolve).catch(nextTask.reject);
+    request.promise().then(request.resolve).catch(request.reject);
 
     this.#debugLog("moving to next-item in queue", { activeRequests: this.#activeRequests, queueLength: this.#queueKey.length });
     delete this.#queue?.[key];

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export class FetchQueue {
     this.#debugLog("moving to next-item in queue", { activeRequests: this.#activeRequests, queueLength: this.#queueKey.length });
     delete this.#queue?.[key];
 
-    if (Boolean(this.#queueKey.length) && Boolean(Object.keys(this.#queue).length)) {
+    if (!Boolean(this.#queueKey.length) || !Boolean(Object.keys(this.#queue).length)) {
       this.#queue = undefined;
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ export class FetchQueue {
   pre: Pre[];
 
   /**
-   * Array of regular-expressions evaluate
+   * Array of regex to queue matching requests; others run immediately.
    */
   #queuingPatterns: RegExp[];
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,7 +1,7 @@
 import { RequestInfo, RequestInit } from "node-fetch";
 
 export type PreHook = (url: URL | RequestInfo, options?: RequestInit) => void;
-export type Pre = { pattern: RegExp | RegExp[], hook: PreHook };
+export type Pre = { pattern: RegExp | RegExp[]; hook: PreHook };
 
 export type FetchQueueConfig = {
   concurrent: number;
@@ -9,4 +9,5 @@ export type FetchQueueConfig = {
   pre?: Pre[];
   queuingPatterns?: RegExp[];
   debug?: boolean;
+  keyBuilderParams?: Array<string>;
 };


### PR DESCRIPTION
#### Description

Avoiding duplicate fetch calls (_with same URL and payload_) by replacing duplicate promise with original promise in the queue

- Refactored queue data-type from `Array` to `Map` with key as stringified JSON of URL, payload and method of the fetch call.

#### Resolutions
- resolves https://github.com/getfundwave/fetch-queue/issues/10
- fixes https://github.com/orgs/getfundwave/discussions/102

#### Depends on

_NA_

#### Deployment

Current pipelines will suffice 
