### PR TITLE
Clone response object for each fetch promise resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.2.0",
+  "version": "1.2.1-resolve-cloned-response.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/fetchq",
-      "version": "1.2.0",
+      "version": "1.2.1-resolve-cloned-response.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.2.1-resolve-cloned-response.0",
+  "version": "1.2.1-resolve-cloned-response.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fundwave/fetchq",
-      "version": "1.2.1-resolve-cloned-response.0",
+      "version": "1.2.1-resolve-cloned-response.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.2.1-resolve-cloned-response.0",
+  "version": "1.2.1-resolve-cloned-response.1",
   "description": "Queue for fetch requests",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fundwave/fetchq",
-  "version": "1.2.0",
+  "version": "1.2.1-resolve-cloned-response.0",
   "description": "Queue for fetch requests",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,9 +311,8 @@ export class FetchQueue {
           const previousRejectHandler = this.#queue[requestKey].reject;
 
           resolveHandler = (value: unknown) => {
-            const clonedResponse = (value as Response).clone();
             previousResolveHandler(value);
-            resolve(clonedResponse);
+            resolve((value as Response)?.clone());
           };
 
           rejectHandler = (reason?: any) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,8 +311,9 @@ export class FetchQueue {
           const previousRejectHandler = this.#queue[requestKey].reject;
 
           resolveHandler = (value: unknown) => {
+            const clonedResponse = (value as Response).clone();
             previousResolveHandler(value);
-            resolve(value);
+            resolve(clonedResponse);
           };
 
           rejectHandler = (reason?: any) => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -294,8 +294,11 @@ describe("test case with start and pause queue", () => {
 
     const duplicateUrls = [...urls, ...urls];
     const promises = duplicateUrls.map((url, urlIndex) => mockFetch(url, urlIndex));
-    const resp = await Promise.all(promises);
+    const responses = await Promise.all(promises);
 
-    expect(resp.length).toBe(8);
+    expect(responses.length).toBe(8);
+    responses.forEach((resp) => {
+      if (resp.ok) expect(resp.json()).resolves.not.toBeNull();
+    })
   }, TEST_TIMEOUT);
 });


### PR DESCRIPTION
#### Description

Fixes shared response instance issue in similar Fetch calls 

#### Resolutions

- fixes https://github.com/getfundwave/fetch-queue/issues/11

#### Depends on

_NA_

#### Deployment

Current pipelines will suffice
